### PR TITLE
feat:  `addRoutes` method 추가

### DIFF
--- a/src/domains/router.ts
+++ b/src/domains/router.ts
@@ -35,6 +35,10 @@ export const createRouter = () => {
       routes.push({ path, handler });
     },
 
+    addRoutes: (newRoutes: Array<Route>) => {
+      routes.push(...newRoutes);
+    },
+
     navigate: (path: string, options: NavigateOptions = {}) => {
       if (!initialized) {
         throw new Error("Router should be initialized first");

--- a/tests/configuring.test.ts
+++ b/tests/configuring.test.ts
@@ -41,4 +41,26 @@ describe("Configuring Routes", () => {
       expect(mockFn).toHaveBeenCalled();
     }
   );
+
+  test("라우터는 여러 개의 라우터를 동시에 등록할 수 있다.", () => {
+    const router = createRouter();
+    const mockFn1 = jest.fn();
+    const mockFn2 = jest.fn();
+
+    router.initialize(window as unknown as Window);
+    router.addRoutes([
+      {
+        path: "/test1",
+        handler: mockFn1,
+      },
+      {
+        path: "/test2",
+        handler: mockFn2,
+      },
+    ]);
+
+    router.navigate("/test2");
+
+    expect(mockFn2).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
#### Description

This PR implements the `addRoutes` method in the router to allow addition of multiple routes. We could use `addRoutes` as follows.

```typescript
router.addRoutes([
      {
        path: "/test1",
        handler: mockFn1,
      },
      {
        path: "/test2",
        handler: mockFn2,
      },
]);
```

#### What are the relevant tickets?

Fixes #3 
