### PR TITLE
Update `initialize` Method to Handle Initial Route Navigation

### DIFF
--- a/src/domains/router.ts
+++ b/src/domains/router.ts
@@ -14,7 +14,9 @@ export const createRouter = () => {
 
   const handleRouteChange = (path: string) => {
     const route = matchRoute(path, routes);
-    if (!route) throw new Error("Path is not registered");
+    if (!route) {
+      return;
+    }
 
     route.handler({
       params: route.params,

--- a/src/domains/router.ts
+++ b/src/domains/router.ts
@@ -2,6 +2,11 @@ import { Route, RouteHandler, NavigateOptions } from "@/types";
 import { matchRoute } from "@/domains/routeMatcher";
 import { createHistoryActions } from "@/domains/historyManager";
 
+type RouterOptions = {
+  routes?: Array<Route>;
+  window?: Window;
+};
+
 export const createRouter = () => {
   const routes = new Array<Route>();
   let initialized = false;
@@ -17,10 +22,24 @@ export const createRouter = () => {
     });
   };
 
+  const addRoute = (path: string, handler: RouteHandler) => {
+    routes.push({ path, handler });
+  };
+
+  const addRoutes = (newRoutes: Array<Route>) => {
+    routes.push(...newRoutes);
+  };
+
   return {
-    initialize: (window: Window = globalThis.window) => {
+    initialize: (options?: RouterOptions) => {
+      const window = options?.window ?? globalThis.window;
+
       if (!window) {
         throw new Error("Router requires a window object");
+      }
+
+      if (options?.routes && options.routes.length > 0) {
+        addRoutes(options.routes);
       }
 
       historyActions = createHistoryActions(window);
@@ -28,17 +47,13 @@ export const createRouter = () => {
         handleRouteChange(window.location.pathname);
       });
 
+      // navigate on load
+      handleRouteChange(window.location.pathname);
+
       initialized = true;
     },
-
-    addRoute: (path: string, handler: RouteHandler) => {
-      routes.push({ path, handler });
-    },
-
-    addRoutes: (newRoutes: Array<Route>) => {
-      routes.push(...newRoutes);
-    },
-
+    addRoute,
+    addRoutes,
     navigate: (path: string, options: NavigateOptions = {}) => {
       if (!initialized) {
         throw new Error("Router should be initialized first");

--- a/tests/configuring.test.ts
+++ b/tests/configuring.test.ts
@@ -33,7 +33,6 @@ describe("Configuring Routes", () => {
     router.initialize({
       window: window as unknown as Window,
       routes: [
-        { path: "/", handler: () => {} },
         { path: "/test", handler: mockFn1 },
         { path: "/test", handler: mockFn2 },
       ],
@@ -56,10 +55,7 @@ describe("Configuring Routes", () => {
 
       router.initialize({
         window: window as unknown as Window,
-        routes: [
-          { path: "/", handler: () => {} },
-          { path, handler: mockFn },
-        ],
+        routes: [{ path, handler: mockFn }],
       });
       router.navigate(navigatePath);
 
@@ -76,7 +72,6 @@ describe("Configuring Routes", () => {
       window: window as unknown as Window,
 
       routes: [
-        { path: "/", handler: () => {} },
         {
           path: "/test1",
           handler: mockFn1,

--- a/tests/configuring.test.ts
+++ b/tests/configuring.test.ts
@@ -10,14 +10,34 @@ describe("Configuring Routes", () => {
     window = dom.window;
   });
 
+  test("앱에 최초 진입시 현재 URL에 해당하는 라우트 핸들러가 실행된다", () => {
+    const mockFn = jest.fn();
+    const router = createRouter();
+
+    // Set initial URL
+    window.history.pushState({}, "", "/initial-path");
+
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [{ path: "/initial-path", handler: mockFn }],
+    });
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
   test("라우터는 등록한 라우트를 순서대로 검사한다.", () => {
     const router = createRouter();
     const mockFn1 = jest.fn();
     const mockFn2 = jest.fn();
 
-    router.initialize(window as unknown as Window);
-    router.addRoute("/test", mockFn1);
-    router.addRoute("/test", mockFn2);
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [
+        { path: "/", handler: () => {} },
+        { path: "/test", handler: mockFn1 },
+        { path: "/test", handler: mockFn2 },
+      ],
+    });
     router.navigate("/test");
 
     expect(mockFn1).toHaveBeenCalled();
@@ -34,8 +54,13 @@ describe("Configuring Routes", () => {
       const router = createRouter();
       const mockFn = jest.fn();
 
-      router.initialize(window as unknown as Window);
-      router.addRoute(path, mockFn);
+      router.initialize({
+        window: window as unknown as Window,
+        routes: [
+          { path: "/", handler: () => {} },
+          { path, handler: mockFn },
+        ],
+      });
       router.navigate(navigatePath);
 
       expect(mockFn).toHaveBeenCalled();
@@ -47,20 +72,23 @@ describe("Configuring Routes", () => {
     const mockFn1 = jest.fn();
     const mockFn2 = jest.fn();
 
-    router.initialize(window as unknown as Window);
-    router.addRoutes([
-      {
-        path: "/test1",
-        handler: mockFn1,
-      },
-      {
-        path: "/test2",
-        handler: mockFn2,
-      },
-    ]);
+    router.initialize({
+      window: window as unknown as Window,
+
+      routes: [
+        { path: "/", handler: () => {} },
+        {
+          path: "/test1",
+          handler: mockFn1,
+        },
+        {
+          path: "/test2",
+          handler: mockFn2,
+        },
+      ],
+    });
 
     router.navigate("/test2");
-
     expect(mockFn2).toHaveBeenCalled();
   });
 });

--- a/tests/listening.test.ts
+++ b/tests/listening.test.ts
@@ -14,8 +14,13 @@ describe("Listening", () => {
     const router = createRouter();
     const mockFn = jest.fn();
 
-    router.initialize(window as unknown as Window);
-    router.addRoute("/test", mockFn);
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [
+        { path: "/", handler: () => {} },
+        { path: "/test", handler: mockFn },
+      ],
+    });
 
     window.history.pushState({}, "", "/test");
     window.dispatchEvent(new window.PopStateEvent("popstate"));

--- a/tests/listening.test.ts
+++ b/tests/listening.test.ts
@@ -16,10 +16,7 @@ describe("Listening", () => {
 
     router.initialize({
       window: window as unknown as Window,
-      routes: [
-        { path: "/", handler: () => {} },
-        { path: "/test", handler: mockFn },
-      ],
+      routes: [{ path: "/test", handler: mockFn }],
     });
 
     window.history.pushState({}, "", "/test");

--- a/tests/navigating.test.ts
+++ b/tests/navigating.test.ts
@@ -14,8 +14,14 @@ describe("Navigating", () => {
     const router = createRouter();
     const mockFn = jest.fn();
 
-    router.initialize(window as unknown as Window);
-    router.addRoute("/test", mockFn);
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [
+        { path: "/", handler: () => {} },
+        { path: "/test", handler: mockFn },
+      ],
+    });
+
     router.navigate("/test");
 
     expect(mockFn).toHaveBeenCalled();
@@ -24,8 +30,16 @@ describe("Navigating", () => {
   test("라우터의 navigate 메소드를 호출하면 history 스택에 새로운 엔트리가 추가되고, URL이 변경된다.", () => {
     const router = createRouter();
 
-    router.initialize(window as unknown as Window);
-    router.addRoute("/test", () => {});
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [
+        {
+          path: "/",
+          handler: () => {},
+        },
+        { path: "/test", handler: () => {} },
+      ],
+    });
     router.navigate("/test");
 
     expect(window.location.href).toBe("http://localhost/test");
@@ -36,8 +50,16 @@ describe("Navigating", () => {
     const router = createRouter();
     const mockFn = jest.fn();
 
-    router.initialize(window as unknown as Window);
-    router.addRoute("/test", mockFn);
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [
+        {
+          path: "/",
+          handler: () => {},
+        },
+        { path: "/test", handler: mockFn },
+      ],
+    });
     router.navigate("/test", { replace: true });
 
     expect(window.location.href).toBe("http://localhost/test");
@@ -50,8 +72,16 @@ describe("Navigating", () => {
     const mockFn = jest.fn();
     const state = { userId: 123 };
 
-    router.initialize(window as unknown as Window);
-    router.addRoute("/test", mockFn);
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [
+        {
+          path: "/",
+          handler: () => {},
+        },
+        { path: "/test", handler: mockFn },
+      ],
+    });
     router.navigate("/test", { state });
 
     expect(window.location.href).toBe("http://localhost/test");

--- a/tests/navigating.test.ts
+++ b/tests/navigating.test.ts
@@ -16,10 +16,7 @@ describe("Navigating", () => {
 
     router.initialize({
       window: window as unknown as Window,
-      routes: [
-        { path: "/", handler: () => {} },
-        { path: "/test", handler: mockFn },
-      ],
+      routes: [{ path: "/test", handler: mockFn }],
     });
 
     router.navigate("/test");
@@ -32,13 +29,7 @@ describe("Navigating", () => {
 
     router.initialize({
       window: window as unknown as Window,
-      routes: [
-        {
-          path: "/",
-          handler: () => {},
-        },
-        { path: "/test", handler: () => {} },
-      ],
+      routes: [{ path: "/test", handler: () => {} }],
     });
     router.navigate("/test");
 
@@ -52,13 +43,7 @@ describe("Navigating", () => {
 
     router.initialize({
       window: window as unknown as Window,
-      routes: [
-        {
-          path: "/",
-          handler: () => {},
-        },
-        { path: "/test", handler: mockFn },
-      ],
+      routes: [{ path: "/test", handler: mockFn }],
     });
     router.navigate("/test", { replace: true });
 
@@ -74,13 +59,7 @@ describe("Navigating", () => {
 
     router.initialize({
       window: window as unknown as Window,
-      routes: [
-        {
-          path: "/",
-          handler: () => {},
-        },
-        { path: "/test", handler: mockFn },
-      ],
+      routes: [{ path: "/test", handler: mockFn }],
     });
     router.navigate("/test", { state });
 

--- a/tests/parameters.test.ts
+++ b/tests/parameters.test.ts
@@ -16,10 +16,7 @@ describe("Path Parameters", () => {
     router.initialize({
       window: window as unknown as Window,
 
-      routes: [
-        { path: "/", handler: () => {} },
-        { path: "/test/:city", handler: mockFn },
-      ],
+      routes: [{ path: "/test/:city", handler: mockFn }],
     });
 
     router.navigate("/test/seoul");
@@ -37,10 +34,7 @@ describe("Path Parameters", () => {
 
     router.initialize({
       window: window as unknown as Window,
-      routes: [
-        { path: "/", handler: () => {} },
-        { path: "/test/:city", handler: mockFn },
-      ],
+      routes: [{ path: "/test/:city", handler: mockFn }],
     });
     router.navigate("/test/seoul?province=gangnam");
 

--- a/tests/parameters.test.ts
+++ b/tests/parameters.test.ts
@@ -11,11 +11,17 @@ describe("Path Parameters", () => {
   });
 
   test("라우터는 URL에서 path parameter를 식별할 수 있다.", () => {
-    const router = createRouter();
     const mockFn = jest.fn();
+    const router = createRouter();
+    router.initialize({
+      window: window as unknown as Window,
 
-    router.initialize(window as unknown as Window);
-    router.addRoute("/test/:city", mockFn);
+      routes: [
+        { path: "/", handler: () => {} },
+        { path: "/test/:city", handler: mockFn },
+      ],
+    });
+
     router.navigate("/test/seoul");
 
     expect(mockFn).toHaveBeenCalledWith(
@@ -29,8 +35,13 @@ describe("Path Parameters", () => {
     const router = createRouter();
     const mockFn = jest.fn();
 
-    router.initialize(window as unknown as Window);
-    router.addRoute("/test/:city", mockFn);
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [
+        { path: "/", handler: () => {} },
+        { path: "/test/:city", handler: mockFn },
+      ],
+    });
     router.navigate("/test/seoul?province=gangnam");
 
     const actualArgs = mockFn.mock.calls[0][0];


### PR DESCRIPTION
### Description

This PR enhances the `initialize` method in the router to ensure proper navigation based on initial routes.

- Ensured that routes are registered before it handles the initial route on load.
- Ensured that the router correctly handles the initial route on load by calling `handleRouteChange` with the current pathname (`window.location.pathname`).

Here is the new `initialize` method .

```js
 const router = createRouter();
 const handler = () => {
     console.log("do something")
 }

 router.initialize({
    routes: [{ path: "/test", handler }], 
  }); 

// Prints "do something" 
```

### What are the relevant tickets?

Fixes #1
