### PR TITLE
Add `beforeLoad` Option to Route

### DIFF
--- a/src/domains/routeMatcher.ts
+++ b/src/domains/routeMatcher.ts
@@ -8,10 +8,10 @@ export const matchRoute = (path: string, routes: Route[]) => {
     ? new URLSearchParams(urlObj.search)
     : undefined;
 
-  for (const { path: route, handler } of routes) {
-    const { isMatch, params } = matchPath(pathname, route);
+  for (const route of routes) {
+    const { isMatch, params } = matchPath(pathname, route.path);
     if (isMatch) {
-      return { handler, params, searchParams };
+      return { params, searchParams, ...route };
     }
   }
   return null;

--- a/src/domains/router.ts
+++ b/src/domains/router.ts
@@ -35,8 +35,8 @@ export const createRouter = () => {
     });
   };
 
-  const addRoute = (path: string, handler: RouteHandler) => {
-    routes.push({ path, handler });
+  const addRoute = (route: Route) => {
+    routes.push(route);
   };
 
   const addRoutes = (newRoutes: Array<Route>) => {

--- a/src/domains/router.ts
+++ b/src/domains/router.ts
@@ -18,6 +18,17 @@ export const createRouter = () => {
       return;
     }
 
+    if (route.beforeLoad) {
+      try {
+        route.beforeLoad({
+          path: route.path,
+          params: route.params,
+        });
+      } catch (e: unknown) {
+        return;
+      }
+    }
+
     route.handler({
       params: route.params,
       searchParams: route.searchParams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,9 +7,17 @@ export type Params = {
 
 export type RouteHandler = (params: Params) => any;
 
+export type Location = {
+  path: string;
+  params: Params;
+};
+
+export type BeforeLoadHandler = (location: Location) => any;
+
 export type Route = {
   path: string;
   handler: RouteHandler;
+  beforeLoad?: BeforeLoadHandler;
 };
 
 export type NavigateOptions = {

--- a/tests/navigating.test.ts
+++ b/tests/navigating.test.ts
@@ -67,4 +67,57 @@ describe("Navigating", () => {
     expect(mockFn).toHaveBeenCalled();
     expect(window.history.state).toEqual(state);
   });
+
+  test("라우터는 beforeLoad 옵션을 통해 route의 handler가 실행되기 전에 beforeRouteHandler를 실행시킬 수 있다.", () => {
+    const router = createRouter();
+    const mockFn1 = jest.fn();
+    const mockFn2 = jest.fn();
+
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [
+        {
+          path: "/test",
+          handler: mockFn1,
+          beforeLoad: mockFn2,
+        },
+      ],
+    });
+
+    router.navigate("/test");
+    expect(mockFn1).toHaveBeenCalled();
+    expect(mockFn2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/test",
+        params: {},
+      })
+    );
+  });
+
+  test("beforeRouteHandler 에서 error 를 throw 한다면, 등록된 route handler 는 실행되지 않는다.", () => {
+    const router = createRouter();
+    const mockFn1 = jest.fn();
+    const mockFn2 = jest.fn();
+
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [
+        {
+          path: "/",
+          handler: mockFn1,
+        },
+        {
+          path: "/test",
+          handler: mockFn2,
+          beforeLoad: () => {
+            throw router.navigate("/");
+          },
+        },
+      ],
+    });
+
+    router.navigate("/test");
+    expect(mockFn1).toHaveBeenCalled();
+    expect(mockFn2).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### Description

This PR introduces the `beforeLoad` handler to the router, allowing custom logic to be executed before a route is loaded.

- Added `beforeLoad` property to the `Route` type.
- Updated the `handleRouteChange` method to call the `beforeLoad` handler if it exists.
- Ensured that the route loading process is aborted if the `beforeLoad` handler throws an error.

Here is an example.

```js
const router = createRouter();
 const routeHandler = () => {
    console.log("Prints Second") // Called after `beforeLoad` handler is called
 } 

  router.initialize({
    window: window as unknown as Window,
    routes: [
      {
        path: "/test",
        handler: routeHandler,
        beforeLoad: () => {
          console.log("Prints First") // Called before `routeHandler` is called
        },
      },
    ],
  });

  router.navigate("/test");

//  Result
// "Prints First"
// "Prints Second"
```

If an error is thrown inside the `beforeLoad` handler, the route handler will not be called. This behavior is useful for scenarios such as redirecting to another page upon login completion.

```js
const router = createRouter();

router.initialize({
  routes: [
    {
      path: "/",
      handler: () => {console.log("Prints Second")}
    },
    {
      path: "/test",
      handler: () => {console.log("Should not be Printed")},
      beforeLoad: () => {
        console.log("Prints First"); // Called before `routeHandler` is called
        throw router.navigate("/")
      },
    },
  ],
});

  router.navigate("/test");

// Result
// "Prints First"
// "Prints Second"
```
### What are the relevant tickets?

Fixes #5 
