### PR TITLE
Add `getParams` Method to Router

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ganu-router",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A lightweight TypeScript router with support for path parameters, search parameters, and browser history management",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/domains/routeMatcher.ts
+++ b/src/domains/routeMatcher.ts
@@ -1,7 +1,10 @@
-import { Route } from "../types";
+import { MatchedRoute, Params, Route } from "../types";
 import { getURLObjFromPath } from "../utils";
 
-export const matchRoute = (path: string, routes: Route[]) => {
+export const matchRoute = (
+  path: string,
+  routes: Route[]
+): MatchedRoute | null => {
   const urlObj = getURLObjFromPath(path);
   const pathname = urlObj.pathname;
   const searchParams = urlObj.search
@@ -9,9 +12,20 @@ export const matchRoute = (path: string, routes: Route[]) => {
     : undefined;
 
   for (const route of routes) {
-    const { isMatch, params } = matchPath(pathname, route.path);
+    const { isMatch, params: matchedParams } = matchPath(pathname, route.path);
     if (isMatch) {
-      return { params, searchParams, ...route };
+      const params: Params = {
+        params: matchedParams,
+      };
+
+      if (searchParams) {
+        params.searchParams = searchParams;
+      }
+
+      return {
+        params,
+        ...route,
+      };
     }
   }
   return null;

--- a/src/domains/router.ts
+++ b/src/domains/router.ts
@@ -1,4 +1,10 @@
-import { Route, RouteHandler, NavigateOptions, MatchedRoute } from "@/types";
+import {
+  Route,
+  RouteHandler,
+  NavigateOptions,
+  MatchedRoute,
+  Params,
+} from "@/types";
 import { matchRoute } from "@/domains/routeMatcher";
 import { createHistoryActions } from "@/domains/historyManager";
 
@@ -11,6 +17,9 @@ export const createRouter = () => {
   const routes = new Array<Route>();
   let initialized = false;
   let historyActions: ReturnType<typeof createHistoryActions>;
+
+  // Current Matching Route
+  let currentRoute: MatchedRoute | null = null;
 
   const handleRouteBeforeLoad = (route: MatchedRoute) => {
     if (!route.beforeLoad) {
@@ -25,6 +34,7 @@ export const createRouter = () => {
 
   const handleRouteAfterLoad = (route: MatchedRoute) => {
     route.handler(route.params);
+    currentRoute = route;
   };
 
   const processRoute = (path: string): MatchedRoute | null => {
@@ -87,8 +97,23 @@ export const createRouter = () => {
       const route = processRoute(path);
       if (route) {
         historyActions.navigate(path, options);
+
+        currentRoute = route;
+
         handleRouteAfterLoad(route);
       }
+    },
+
+    getParams: (): Params => {
+      if (!initialized) {
+        throw new Error("Router should be initialized first");
+      }
+
+      if (!currentRoute) {
+        throw new Error("There is no matching route.");
+      }
+
+      return currentRoute.params;
     },
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,10 @@ export type Route = {
   beforeLoad?: BeforeLoadHandler;
 };
 
+export type MatchedRoute = Route & {
+  params: Params;
+};
+
 export type NavigateOptions = {
   replace?: boolean;
   state?: any;

--- a/tests/navigating.test.ts
+++ b/tests/navigating.test.ts
@@ -89,7 +89,9 @@ describe("Navigating", () => {
     expect(mockFn2).toHaveBeenCalledWith(
       expect.objectContaining({
         path: "/test",
-        params: {},
+        params: {
+          params: {},
+        },
       })
     );
   });

--- a/tests/parameters.test.ts
+++ b/tests/parameters.test.ts
@@ -42,4 +42,21 @@ describe("Path Parameters", () => {
     expect(actualArgs.params).toEqual({ city: "seoul" });
     expect(actualArgs.searchParams.toString()).toBe("province=gangnam");
   });
+
+  test("라우터는 getParams를 통해 현재 route의 params 에 대한 정보를 가져올 수 있다.", () => {
+    const router = createRouter();
+    const mockFn = jest.fn();
+
+    router.initialize({
+      window: window as unknown as Window,
+      routes: [{ path: "/test/:city", handler: mockFn }],
+    });
+    router.navigate("/test/seoul?province=gangnam");
+
+    const params = router.getParams();
+    expect(params).toEqual({
+      params: { city: "seoul" },
+      searchParams: new URLSearchParams("province=gangnam"),
+    });
+  });
 });


### PR DESCRIPTION
### Description

This PR introduces the `getParams` method to the router, allowing users to access route parameters from anywhere in the code. Initially, the goal was to access `window.location.pathname` directly, but it became clear that there is a need to retrieve route parameters at any time, not just within the route handler.

- Added `getParams` method to the router.
- Updated the router to store the current route parameters, making them accessible via the `getParams` method.

Here is how we can use `getParams`

```js
  const router = createRouter();
 
  router.initialize({
    window: window as unknown as Window,
    routes: [{ path: "/test/:city", handler: mockFn }],
  });
  router.navigate("/test/seoul?province=gangnam");

  const params = router.getParams(); 

  /* Params would be like 
   {
      params: { city: "seoul" },
      searchParams: new URLSearchParams("province=gangnam"),
    }
  */
```

### What are the relevant tickets?

Fixes #10 
